### PR TITLE
[TG-1937] Expose private method to facilitate accessing hidden fields.

### DIFF
--- a/src/main/java/com/diffblue/deeptestutils/Reflector.java
+++ b/src/main/java/com/diffblue/deeptestutils/Reflector.java
@@ -122,7 +122,7 @@ public final class Reflector {
    *     subclass or implementor thereof), or if an unwrapping conversion fails.
    * @exception IllegalAccessException if an error occurs
    */
-  private static <T> Object getInstanceField(
+  public static <T> Object getInstanceField(
       final Class<T> c,
       final Object o,
       final String fieldName)


### PR DESCRIPTION
The variation of ```getInstanceField``` which is currently private needs to be exposed in order enable hidden fields to be accessed. These are fields in the base class which have been hidden by a field of the same name in the child class.