### PR TITLE
[TG-2850] Enforce creation of package-info.class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
             <configuration>
               <source>1.8</source>
               <target>1.8</target>
+              <compilerArgument>-Xpkginfo:always</compilerArgument>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
At the moment maven does not create package-info.class from package-info.java. This means that it recompiles the files every time mvn compile is run, because it detects a missing classfile.

This commit adds a workaround that enforcess class file creation (this is what's recommended, see for example help for -Xpkginfo at https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javac.html)