### PR TITLE
Release/merge 1.1.0 back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.1.0
+=====
+* Update license to BSD-3 Clause
+
+
 1.0.0
 =====
  * Initial release of deeptest-utils


### PR DESCRIPTION
The merge of master/1.1.0 back into develop seems to have been omitted.