### PR TITLE
Fallback on `repo1.maven.org` for java6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,15 @@ install:
       export M2_HOME=$PWD/apache-maven-${CUSTOM_MVN_VERION};
       export PATH=$M2_HOME/bin:$PATH;
       mvn -version;
+      mkdir ~/.m2;
+      echo "<settings>
+  <mirrors>
+    <mirror>
+      <id>HTTP fallback</id>
+      <name>Maven repo1</name>
+      <url>http://repo1.maven.org/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>" > ~/.m2/settings.xml;
     fi


### PR DESCRIPTION
Maven dropped support for TLS1.1 on June 18th, locking out our Java 6 support. Oracle seems to have updated its JDK but openJDK doesn't support TLS1.2 or higher.

cf. https://central.sonatype.org/articles/2018/May/04/discontinue-support-for-tlsv11-and-below/?__hstc=31049440.39bec4937410179f17181d98964c7446.1529416496779.1529416496779.1529416496779.1&__hssc=31049440.1.1529416496780&__hsfp=2831431618

This patch creates a local `settings.xml` file that points to the HTTP repo `repo1.maven.org`.