### PR TITLE
Update javassist version and test in java 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
   - jdk: openjdk7
   - jdk: openjdk8
   - jdk: oraclejdk8
+  - jdk: openjdk9
+  - jdk: oraclejdk9
 
 
 # `mvn` version 3.2.5 is the last that supports Java6, therefore we need to get

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.21.0-GA</version>
+      <version>3.22.0-GA</version>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>


### PR DESCRIPTION
Travis uses java 9 for mac, which requires a new version of javassist.