### PR TITLE
[TG-3765] Fix check in toThrowableClass

### DIFF
--- a/src/main/java/com/diffblue/deeptestutils/Reflector.java
+++ b/src/main/java/com/diffblue/deeptestutils/Reflector.java
@@ -262,7 +262,7 @@ public final class Reflector {
   }
 
   /**
-   * Returns class of exception or Throwable.
+   * Returns the Class of an Object if it extends or implements Throwable.
    *
    * @param className name of class as <code>String</code>
    * @return the <code>Class</code> object
@@ -272,7 +272,7 @@ public final class Reflector {
       final String className) {
     final Class throwableClass = Throwable.class;
     Class<?> cl = forName(className);
-    if (cl.isAssignableFrom(throwableClass)) {
+    if (throwableClass.isAssignableFrom(cl)) {
       return (Class<? extends Throwable>) cl;
     } else {
       throw

--- a/src/test/java/com/diffblue/deeptestutils/PublicException.java
+++ b/src/test/java/com/diffblue/deeptestutils/PublicException.java
@@ -1,0 +1,8 @@
+package com.diffblue.deeptestutils;
+
+public class PublicException extends Exception {
+
+    private class PrivateInnerException extends PublicException{
+    }
+
+}

--- a/src/test/java/com/diffblue/deeptestutils/ReflectorTest.java
+++ b/src/test/java/com/diffblue/deeptestutils/ReflectorTest.java
@@ -189,4 +189,54 @@ public class ReflectorTest {
 
   }
 
+  @org.junit.Test
+  public void toThrowableClassThrowable() {
+      // Arrange
+      String testClassName = "java.lang.Throwable";
+      Class expectedClass = Throwable.class;
+
+      // Act
+      Class retval = Reflector.toThrowableClass(testClassName);
+
+      // Assert result
+      Assert.assertEquals(expectedClass, retval);
+  }
+
+  @org.junit.Test
+  public void toThrowableClassSubClassofThrowable() {
+      // Arrange
+      String testClassName = "java.lang.Exception";
+      Class expectedClass = Exception.class;
+
+      // Act
+      Class retval = Reflector.toThrowableClass(testClassName);
+
+      // Assert result
+      Assert.assertEquals(expectedClass, retval);
+  }
+
+  @org.junit.Test
+  public void toThrowableClassPrivateSubClassofThrowable()
+          throws ClassNotFoundException{
+      // Arrange
+      String testClassName = "com.diffblue.deeptestutils.PublicException$PrivateInnerException";
+      Class expectedClass = Class.forName("com.diffblue.deeptestutils.PublicException$PrivateInnerException");
+
+      // Act
+      Class retval = Reflector.toThrowableClass(testClassName);
+
+      // Assert result
+      Assert.assertEquals(expectedClass, retval);
+  }
+
+  @org.junit.Test
+  public void toThrowableClassNotException() {
+      // Arrange
+      String testClassName = "java.lang.String";
+
+      // Act
+      thrown.expect(DeeptestUtilsRuntimeException.class);
+      Class retval = Reflector.toThrowableClass(testClassName);
+  }
+
 }


### PR DESCRIPTION
The object and parameter were reversed, which was causing problems with inner exceptions (the only place this is used currently) in test-gen. Adds tests for this method.

..

raw test gen bump: https://github.com/diffblue/test-gen/pull/2214