### PR TITLE
[TG-4312]  Expose private overload of `setField`

### DIFF
--- a/src/main/java/com/diffblue/deeptestutils/Reflector.java
+++ b/src/main/java/com/diffblue/deeptestutils/Reflector.java
@@ -91,8 +91,9 @@ public final class Reflector {
                                   final String fieldName, final Object newVal) {
 
     if (c == null) {
-      final NoSuchFieldException e = new NoSuchFieldException();
-      throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
+      throw new DeeptestUtilsRuntimeException(
+          "Class of the field to be set cannot be null.",
+          (new NoSuchFieldException()).getCause());
     }
     Field field = null;
     for (Field f : c.getDeclaredFields()) {

--- a/src/main/java/com/diffblue/deeptestutils/Reflector.java
+++ b/src/main/java/com/diffblue/deeptestutils/Reflector.java
@@ -95,7 +95,7 @@ public final class Reflector {
    *     subclass or implementor thereof), or if an unwrapping conversion fails.
    * @exception IllegalAccessException if an error occurs
    */
-  private static <T> void setField(final Class<T> c, final Object o,
+  public static <T> void setField(final Class<T> c, final Object o,
                                    final String fieldName, final Object newVal)
       throws NoSuchFieldException, IllegalArgumentException,
              IllegalAccessException {

--- a/src/main/java/com/diffblue/deeptestutils/Reflector.java
+++ b/src/main/java/com/diffblue/deeptestutils/Reflector.java
@@ -47,11 +47,7 @@ public final class Reflector {
                               final Object newVal) {
     try {
       setField(obj.getClass(), obj, fieldName, newVal);
-    } catch (NoSuchFieldException e) {
-      throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
     } catch (IllegalArgumentException e) {
-      throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
-    } catch (IllegalAccessException e) {
       throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
     }
   }
@@ -70,11 +66,7 @@ public final class Reflector {
                                         final Object newVal) {
     try {
       setField(c, null, fieldName, newVal);
-    } catch (NoSuchFieldException e) {
-      throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
     } catch (IllegalArgumentException e) {
-      throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
-    } catch (IllegalAccessException e) {
       throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
     }
   }
@@ -96,12 +88,11 @@ public final class Reflector {
    * @exception IllegalAccessException if an error occurs
    */
   public static <T> void setField(final Class<T> c, final Object o,
-                                   final String fieldName, final Object newVal)
-      throws NoSuchFieldException, IllegalArgumentException,
-             IllegalAccessException {
+                                  final String fieldName, final Object newVal) {
 
     if (c == null) {
-      throw new NoSuchFieldException();
+      final NoSuchFieldException e = new NoSuchFieldException();
+      throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
     }
     Field field = null;
     for (Field f : c.getDeclaredFields()) {
@@ -117,10 +108,19 @@ public final class Reflector {
       property.setAccessible(true);
 
       // remove final modifier
-      Field modifiersField = Field.class.getDeclaredField("modifiers");
+      Field modifiersField;
+      try {
+        modifiersField = Field.class.getDeclaredField("modifiers");
+      } catch (NoSuchFieldException e) {
+        throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
+      }
       modifiersField.setAccessible(true);
-      modifiersField.setInt(property,
-                            property.getModifiers() & ~Modifier.FINAL);
+      try {
+        modifiersField.setInt(property,
+                              property.getModifiers() & ~Modifier.FINAL);
+      } catch (IllegalAccessException e) {
+        throw new DeeptestUtilsRuntimeException(e.getMessage(), e.getCause());
+      }
       try {
         property.set(o, newVal);
       } catch (IllegalAccessException ex) {

--- a/src/main/java/com/diffblue/deeptestutils/Reflector.java
+++ b/src/main/java/com/diffblue/deeptestutils/Reflector.java
@@ -124,7 +124,8 @@ public final class Reflector {
       try {
         property.set(o, newVal);
       } catch (IllegalAccessException ex) {
-        throw new RuntimeException(ex); // Should never happen.
+        // Should never happen.
+        throw new DeeptestUtilsRuntimeException(ex.getMessage(), ex.getCause());
       }
     }
   }

--- a/src/test/java/com/diffblue/deeptestutils/ReflectorTest.java
+++ b/src/test/java/com/diffblue/deeptestutils/ReflectorTest.java
@@ -152,7 +152,7 @@ public class ReflectorTest {
       Object newVal = null;
 
       /* Act */
-      thrown.expect(NoSuchFieldException.class);
+      thrown.expect(DeeptestUtilsRuntimeException.class);
       try {
         Class<?> c0 = Reflector.forName("com.diffblue.deeptestutils.Reflector");
         Method m = c0.getDeclaredMethod("setField", Reflector.forName("java.lang.Class"), Reflector.forName("java.lang.Object"), Reflector.forName("java.lang.String"), Reflector.forName("java.lang.Object"));


### PR DESCRIPTION
An additional overload of `setField` needs to be exposed outside of deeptest utils, so that it can be used to set inaccessible, hidden fields. In this context a hidden field is a field in a base class which has the same name as another field which is defined in another class which extends the base class.