### PR TITLE
Downgrade Powermock from 1.6.6 to 1.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,12 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.6</version>
+      <version>1.6.5</version>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.6</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
All our tools use 1.6.5 (test-gen, platform etc)