### PR TITLE
Fix wrong assertion in unit test

### DIFF
--- a/src/test/java/com/diffblue/deeptestutils/mock/MethodMatcherTest.java
+++ b/src/test/java/com/diffblue/deeptestutils/mock/MethodMatcherTest.java
@@ -170,7 +170,7 @@ public class MethodMatcherTest {
     // verify that we find the correct method according to Java language specification
     Assert.assertEquals(parent.argSubtype(child).toString(), s5);
     // verify that the matched method returns what we expect it to return
-    Assert.assertEquals("4", s6);
+    Assert.assertEquals("4", s5);
   }
 
   @org.junit.Test


### PR DESCRIPTION
:pick: Other tests check the output of `method`, not `methodUsingWholeSignature`.

Release not necessary.