### PR TITLE
Remove openjdk6 Travis build and pom profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,15 @@
 addons:
   apt:
     packages:
-      - openjdk-6-jdk
       - openjdk-7-jdk
 
 language: java
 
 matrix:
   include:
-  - jdk: openjdk6
-    env: CUSTOM_MVN_VERION="3.2.5"
   - jdk: openjdk7
   - jdk: openjdk8
   - jdk: oraclejdk8
 
-
-# `mvn` version 3.2.5 is the last that supports Java6, therefore we need to get
-# that version for the openjdk6 build.
-# cf. https://github.com/travis-ci/enterprise-installation/issues/14#issuecomment-329983790
-
 install:
-  - |
-    # Install custom version of Maven
-    set -eo pipefail
-    if [[ -n "${CUSTOM_MVN_VERION}" ]]; then
-      wget -O- "https://archive.apache.org/dist/maven/maven-3/${CUSTOM_MVN_VERION}/binaries/apache-maven-${CUSTOM_MVN_VERION}-bin.tar.gz" | tar -C "${HOME}" -xz
-      export M2_HOME="${HOME}/apache-maven-${CUSTOM_MVN_VERION}"
-      export PATH="${M2_HOME}/bin:${PATH}"
-      echo "
-        <settings>
-          <mirrors>
-            <mirror>
-              <id>HTTP fallback</id>
-              <name>Maven repo1</name>
-              <url>http://repo1.maven.org/maven2/</url>
-              <mirrorOf>central</mirrorOf>
-            </mirror>
-          </mirrors>
-        </settings>
-      " > "${HOME}/.m2/settings.xml"
-    fi
-    set +eo pipefail
-
   - mvn -version

--- a/pom.xml
+++ b/pom.xml
@@ -141,9 +141,7 @@
     <profile>
       <id>stdbuild</id>
       <activation>
-        <!-- this selects any Java7 JDK or higher, split was needed as
-             checkstyle is incompatible with JDK6 -->
-        <jdk>[1.7,)</jdk>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>
@@ -197,49 +195,6 @@
              -->
             <configuration>
               <useSystemClassLoader>false</useSystemClassLoader>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>  <!-- nb this must be the same as the 'id' field in 'settings.xml' -->
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <!-- http://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release -->
-              <!-- With the property autoReleaseAfterClose set to false you can manually -->
-              <!-- inspect the staging repository in the Nexus Repository Manager and trigger a -->
-              <!-- release of the staging repository later with mvn nexus-staging:release -->
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-        <profile>
-      <id>jdk6build</id>
-      <activation>
-        <jdk>1.6</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.1</version>
-            <configuration>
-              <source>1.6</source>
-              <target>1.6</target>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.0.0</version>
-            <configuration>
-              <show>private</show>
-              <nohelp>true</nohelp>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
openjdk6 is no longer supported on Travis. Since we have source and target for the compiler set to 1.6 in the pom file anyway, we just remove the Java 6 build and corresponding profile for now. To make sure we're testing compilation with other sources/targets/compilers, https://diffblue.atlassian.net/browse/TG-5884 should be done in the future.