### PR TITLE
Fix wrapping of exceptions within InvocationTargetExceptions in Reflector.getInstance

### DIFF
--- a/src/test/java/com/diffblue/deeptestutils/regression/ReflectorGetInstanceTest.java
+++ b/src/test/java/com/diffblue/deeptestutils/regression/ReflectorGetInstanceTest.java
@@ -149,9 +149,7 @@ public class ReflectorGetInstanceTest {
   // When we call Reflector.getInstance on an abstract class whose static
   // initialiser throws an exception, it should wrap this exception within an
   // InvocationTargetException.
-  // TODO Fix this (TG-5895) and enable this test.
   @Test
-  @Ignore
   public void abstractClassWithBadStaticInit() throws Throwable {
     try {
       Reflector.getInstance(


### PR DESCRIPTION
Previously only the ExceptionInInitializerErrors thrown by Class.forName were unwrapped and their cause wrapped within an InvocationTargetException. But ObjenesisStd.newInstance can also throw these errors, so we should do the same in this case. This fixes TG-5895, and the corresponding test is enabled.

This is currently based on https://github.com/diffblue/deeptest-utils/pull/61 and should not be merged until it is rebased on develop.