### PR TITLE
[TG-8457] Upgrade javassist to 3.25.0-GA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
   - jdk: openjdk7
   - jdk: openjdk8
   - jdk: oraclejdk8
+  - jdk: openjdk11
+  - jdk: oraclejdk11
 
 install:
   - mvn -version

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.21.0-GA</version>
+      <version>3.25.0-GA</version>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>


### PR DESCRIPTION
Makes reflection work in Java 11.

See also https://github.com/diffblue/deeptest-utils/pull/69 which does this and more.