### PR TITLE
Upgrade all maven dependencies in pom.xml file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.2</version>
+      <version>4.13-beta-3</version>
     </dependency>
   </dependencies>
   <!-- this profile gpg signs the artifacts -->

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.5</version>
+      <version>1.7.4</version>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,13 +59,13 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.5</version>
+      <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <version>2.0.2-beta</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
More complete alternative to https://github.com/diffblue/deeptest-utils/pull/68, generated by running `mvn versions:use-latest-versions`

Did not upgrade objenesis as this caused build to fail for JDK 7.